### PR TITLE
Added partials support.

### DIFF
--- a/tasks/codekit.js
+++ b/tasks/codekit.js
@@ -27,6 +27,15 @@ module.exports = function(grunt) {
       // Concat specified files
 
       var src = f.src.filter(function(filepath) {
+        // Check for Kit partials and don’t include them in the compile list
+        // (They will be compiled only via imports and can cause errors if there
+        // are variables that they use that are defined in the parent scope.)
+        var basefilepath = path.basename(filepath);
+        if (basefilepath[0] === "_") {
+          grunt.verbose.ok("Encountered partial " + filepath + " — not compiling it directly.");
+          return false;
+        }
+               
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {
           grunt.log.error('Source file "' + filepath + '" not found.');


### PR DESCRIPTION
CodeKit partials can be flagged by including a trailing underscore (_) in the file name. If these files are compiled directly, the build may fail if, for example, there are variables referenced in the partial that are defined in the parent Kit file. This update checks for partials and makes sure they are not compiled directly. (See the “The ‘Partial’ Convention” section at http://incident57.com/codekit/help.html#kit)
